### PR TITLE
fix: change maxUnavailable to 0 for zero-downtime deployments

### DIFF
--- a/deploy/mcp-for-docs/templates/mcp-for-docs.yaml
+++ b/deploy/mcp-for-docs/templates/mcp-for-docs.yaml
@@ -10,7 +10,7 @@ spec:
       type: RollingUpdate
       rollingUpdate:
         maxSurge: 1
-        maxUnavailable: 1
+        maxUnavailable: 0
   selector:
     matchLabels:
       app: mcp-for-docs


### PR DESCRIPTION
## Summary
Fixes rolling deployment to ensure zero downtime by changing `maxUnavailable` from 1 to 0.

## Problem
With `minReplicas: 1` and `maxReplicas: 1`, the current configuration allows the old pod to be terminated before the new pod is ready, causing downtime during deployments.

## Solution
Changed `maxUnavailable` to 0 in the deployment strategy, ensuring the old pod remains running until the new pod passes readiness checks.

## Changes
- `deploy/mcp-for-docs/templates/mcp-for-docs.yaml`: Changed `maxUnavailable: 1` to `maxUnavailable: 0`

## Test Plan
- [x] Helm template validates
- [ ] Deploy to staging and verify rolling update behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced deployment strategy to ensure zero downtime during service updates by maintaining full pod availability throughout rollouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->