### PR TITLE
fix: apply patch-package in Dockerfile before build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,10 @@ WORKDIR /app
 
 ADD ./package.json /app/package.json
 ADD ./bun.lock /app/bun.lock
+ADD ./patches /app/patches
 
 RUN bun install --frozen-lockfile
+RUN npx patch-package
 
 ADD ./ /app/
 

--- a/deploy/mcp-for-docs/Chart.yaml
+++ b/deploy/mcp-for-docs/Chart.yaml
@@ -3,4 +3,4 @@ name: mcp-for-docs
 description: Helm chart for Appwrite MCP for Docs server
 type: application
 version: 0.1.0
-appVersion: '1.0.0'
+appVersion: '1.0.4'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appwrite.io/mcp-for-docs",
-  "version": "1.0.0",
+  "version": "1.0.4",
   "main": "index.js",
   "scripts": {
     "build": "tsc && mcp-build",


### PR DESCRIPTION
## Summary

- Copies `patches/` directory into the Docker image **before** `bun install`, so `patch-package` can find and apply the mcp-framework session cleanup patch
- Explicitly runs `npx patch-package` after install, since bun's `--frozen-lockfile` skips postinstall scripts

Without this fix, the session cleanup patch from #12 never applies in production, causing stale sessions to accumulate and fill logs with "No connection established" errors.

## Test plan

- [ ] Build Docker image and verify patch applies (look for `patch-package` output during build)
- [ ] Deploy and confirm session cleanup logs appear instead of error spam
- [ ] Verify `npx patch-package` exits 0 during image build